### PR TITLE
Fix compatibility with NumPy 1.x

### DIFF
--- a/ripple_detection/detectors.py
+++ b/ripple_detection/detectors.py
@@ -17,6 +17,9 @@ from ripple_detection.core import (
     threshold_by_zscore,
 )
 
+# NumPy 2.x renamed trapz to trapezoid; use getattr for compatibility
+trapezoid = getattr(np, "trapezoid", np.trapz)  # type: ignore[attr-defined]  # noqa: NPY201
+
 
 def _validate_lfp_dimensions(filtered_lfps: NDArray) -> None:
     """Validate that LFP array is 2D with shape (n_time, n_channels).
@@ -856,12 +859,6 @@ def _get_event_stats(
         - max_speed, min_speed, median_speed, mean_speed: Speed statistics
 
     """
-    try:
-        from numpy import trapezoid
-    except ImportError:
-        # NumPy 1.x
-        from numpy import trapz as trapezoid
-
     event_times_arr = np.asarray(event_times)
     time_arr = np.asarray(time)
     zscore_metric_arr = np.asarray(zscore_metric)

--- a/ripple_detection/detectors.py
+++ b/ripple_detection/detectors.py
@@ -856,6 +856,12 @@ def _get_event_stats(
         - max_speed, min_speed, median_speed, mean_speed: Speed statistics
 
     """
+    try:
+        from numpy import trapezoid
+    except ImportError:
+        # NumPy 1.x
+        from numpy import trapz as trapezoid
+
     event_times_arr = np.asarray(event_times)
     time_arr = np.asarray(time)
     zscore_metric_arr = np.asarray(zscore_metric)
@@ -892,8 +898,8 @@ def _get_event_stats(
         median_zscore.append(np.median(event_zscore))
         max_zscore.append(np.max(event_zscore))
         min_zscore.append(np.min(event_zscore))
-        area.append(np.trapezoid(event_zscore, time_arr[ind]))
-        total_energy.append(np.trapezoid(event_zscore**2, time_arr[ind]))
+        area.append(trapezoid(event_zscore, time_arr[ind]))
+        total_energy.append(trapezoid(event_zscore**2, time_arr[ind]))
         duration.append(end_time - start_time)
         max_speed.append(np.max(speed_arr[ind]))
         min_speed.append(np.min(speed_arr[ind]))

--- a/ripple_detection/detectors.py
+++ b/ripple_detection/detectors.py
@@ -17,8 +17,11 @@ from ripple_detection.core import (
     threshold_by_zscore,
 )
 
-# NumPy 2.x renamed trapz to trapezoid; use getattr for compatibility
-trapezoid = getattr(np, "trapezoid", np.trapz)  # type: ignore[attr-defined]  # noqa: NPY201
+# NumPy 2.x renamed trapz to trapezoid
+if hasattr(np, "trapezoid"):
+    trapezoid = np.trapezoid
+else:
+    trapezoid = np.trapz  # type: ignore[attr-defined]  # noqa: NPY201
 
 
 def _validate_lfp_dimensions(filtered_lfps: NDArray) -> None:


### PR DESCRIPTION
`numpy.trapezoid` is only defined for NumPy 2. Fallback to `numpy.trapz` when using NumPy version 1.x.